### PR TITLE
Subscribe to Seeked + QTimer

### DIFF
--- a/include/SpotiFire.hpp
+++ b/include/SpotiFire.hpp
@@ -2,6 +2,8 @@
 
 #include <QObject>
 #include <QDBusMessage>
+#include <QThread>
+#include <QTimer>
 
 class SpotiFire : public QObject
 {
@@ -15,14 +17,17 @@ public:
 
 public Q_SLOTS:
     void songChanged(QDBusMessage msg);
+    void positionChanged(QDBusMessage msg);
 
 private:
     uint64_t getSpotifyProgress();
     void updateSpotifyProgress(uint64_t position);
     void updateSongDuration();
 
-    const QString &SPOTIFY_SERVICE = "org.mpris.MediaPlayer2.spotify";
-    const QString &MPRIS_PATH = "/org/mpris/MediaPlayer2";
-    const QString &DBUS_INTERFACE = "org.freedesktop.DBus.Properties";
-    const QString &MPRIS_PLAYER = "org.mpris.MediaPlayer2.Player";
+    const QString SPOTIFY_SERVICE = "org.mpris.MediaPlayer2.spotify";
+    const QString MPRIS_PATH = "/org/mpris/MediaPlayer2";
+    const QString DBUS_INTERFACE = "org.freedesktop.DBus.Properties";
+    const QString MPRIS_PLAYER = "org.mpris.MediaPlayer2.Player";
+
+    QTimer *progressTimer;
 };

--- a/src/SpotiFire.cpp
+++ b/src/SpotiFire.cpp
@@ -81,8 +81,6 @@ void SpotiFire::positionChanged(QDBusMessage msg)
     updateSpotifyProgress(newPosition);
 }
 
-
-
 void SpotiFire::updateSongDuration()
 {
 	QDBusInterface iface(SPOTIFY_SERVICE, MPRIS_PATH, DBUS_INTERFACE);

--- a/src/SpotiFire.cpp
+++ b/src/SpotiFire.cpp
@@ -2,8 +2,8 @@
 #include <QDBusArgument>
 #include <QDBusConnection>
 #include <QDBusInterface>
-#include <chrono>
-#include <thread>
+#include <QTimer>
+#include <QThread>
 
 SpotiFire::SpotiFire(QObject* parent) :
 	QObject(parent)
@@ -13,16 +13,20 @@ SpotiFire::SpotiFire(QObject* parent) :
 	updateSongDuration();
 
 	dbus.connect(SPOTIFY_SERVICE, MPRIS_PATH, DBUS_INTERFACE, "PropertiesChanged", this, SLOT(songChanged(QDBusMessage)));
+	dbus.connect(SPOTIFY_SERVICE, MPRIS_PATH, MPRIS_PLAYER, "Seeked", this, SLOT(positionChanged(QDBusMessage)));
 
-	while (dbus.isConnected())
-	{
-		uint64_t progress = getSpotifyProgress();
-		updateSpotifyProgress(progress);
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-	}
+    progressTimer = new QTimer(this);
+    progressTimer->setInterval(1000);
+    connect(progressTimer, &QTimer::timeout, this, [this] {
+		updateSpotifyProgress(getSpotifyProgress());
+	});
+    progressTimer->start();
 }
 
-SpotiFire::~SpotiFire() = default;
+SpotiFire::~SpotiFire()
+{
+	progressTimer->stop();
+}
 
 uint64_t SpotiFire::getSpotifyProgress()
 {
@@ -70,6 +74,14 @@ void SpotiFire::songChanged(QDBusMessage msg)
 	}
 	arg.endMap();
 }
+
+void SpotiFire::positionChanged(QDBusMessage msg)
+{
+    uint64_t newPosition = msg.arguments().at(0).value<qint64>();
+    updateSpotifyProgress(newPosition);
+}
+
+
 
 void SpotiFire::updateSongDuration()
 {


### PR DESCRIPTION
Firstly, thanks for great app!
What's basically done:
- [x] Instead of `sleep`, used `QTimer`, because `sleep` blocks event loop, and as a result, DBus signals like `PropertiesChanged` or `Seeked` are not processed until the sleep finishes. Now every signal processes in background momentally.
- [x] Added subscription to DBus's Signal `Seeked`, which called when user in Spotify seeks to another position of song. Now new position will be applied immediately, not on next Timer start
- [x] Removed `&` at QString's with consts creation because it caused problems, when these strings live only for the duration of the expression, but not beyond the constructor. Therefore, it creates a "dangling reference" after the constructor, which leaded to the warning.

